### PR TITLE
Fix an issue with nan mean_shadow

### DIFF
--- a/boostaroota/boostaroota.py
+++ b/boostaroota/boostaroota.py
@@ -134,6 +134,7 @@ def _reduce_vars_xgb(x, y, metric, this_round, cutoff, n_iterations, delta, sile
 
     # Get mean value from the shadows
     mean_shadow = shadow_vars['Mean'].mean() / cutoff
+    mean_shadow = mean_shadow if not np.isnan(mean_shadow) else 0
     real_vars = real_vars[(real_vars.Mean > mean_shadow)]
 
     #Check for the stopping criteria


### PR DESCRIPTION
There is a case when none of the shadow features are used in the fit, hence the shadow values are nan. This leads to removal of all real features. 