### PR TITLE
Fix type clash in mean computation

### DIFF
--- a/boostaroota/boostaroota.py
+++ b/boostaroota/boostaroota.py
@@ -127,7 +127,7 @@ def _reduce_vars_xgb(x, y, metric, this_round, cutoff, n_iterations, delta, sile
         if not silent:
             print("Round: ", this_round, " iteration: ", i)
 
-    df['Mean'] = df.mean(axis=1)
+    df['Mean'] = df.drop(columns=['feature']).mean(axis=1)
     #Split them back out
     real_vars = df[~df['feature'].isin(shadow_names)]
     shadow_vars = df[df['feature'].isin(shadow_names)]


### PR DESCRIPTION
Fix issue with pandas 2.2.2.

Reproduce with:
```
import pandas as pd
from boostaroota import BoostARoota

dummy = pd.DataFrame(
    {
        "A": [65, 235, 23523, 52, 35, 23],
        "B": [1, 2, 5, 9, 2, 3],
        "C": [1, 2, 3, 4, 5, 6],
    }
)
labels = [1, 0, 1, 0, 1, 0]

br = BoostARoota(metric="logloss", silent=False)
br.fit(dummy, labels)
```